### PR TITLE
feat: accept configuration file ⚙️

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 demo
+.vscode

--- a/README.md
+++ b/README.md
@@ -2,12 +2,74 @@
 
 📦 This project give the possibility to generate a Google codelab with asciidoc or markdown files.
 
-You can use this module directly from the command line
+You can use this module directly from the command line or from your code !
+
+## How to use ?
+
+### Command line
 
 ```shell
-npx @dxdeveloperexperience/codelab-generator  ./index.adoc ./target
+npx @dxdeveloperexperience/codelab-generator ./index.adoc ./target
 
-npx @dxdeveloperexperience/codelab-generator  ./index.md ./target
+npx @dxdeveloperexperience/codelab-generator ./index.md ./target
+```
+
+### In your code
+
+```js
+const codelab = require("@dxdeveloperexperience/codelab-generator");
+
+// ...
+await codelab(labTmpFile, labsOutputDir);
+```
+
+## Configuration
+
+### Values
+
+| Name | Values | Description                                   |
+| ---- | ------ | --------------------------------------------- |
+| base | ""     | The base url of bower_components and elements |
+
+### Examples
+
+From shell
+```shell
+npx @dxdeveloperexperience/codelab-generator ./index.adoc ./target path/to/config.json
+
+npx @dxdeveloperexperience/codelab-generator ./index.md ./target path/to/config.json
+```
+
+the config.json
+
+```json
+{
+  "base": "baseurl/test/"
+}
+```
+
+or
+
+```js
+const codelab = require("@dxdeveloperexperience/codelab-generator");
+
+// ...
+await codelab(labTmpFile, labsOutputDir, { base: "" });
+```
+
+Result, it will convert template
+from:
+
+```html
+<script src="{{ &base }}bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+<link rel="import" href="{{ &base }}elements/codelab.html" />
+```
+
+to:
+
+```html
+<script src="baseurl/test/bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+<link rel="import" href="baseurl/test/elements/codelab.html" />
 ```
 
 ## Contributors

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,14 +1,28 @@
 #!/usr/bin/env node
 
+const path = require("path");
 const [, , ...args] = process.argv;
+let config = {};
 
-if (args.length !== 2) {
-  console.error("You should define two arguments to this command line");
+if (args.length < 2) {
+  console.error(
+    "You should define a minimum of two arguments to this command line"
+  );
   process.exit();
 }
 
-const path = require("path");
+if (args.length === 3) {
+  const configPath = path.resolve(process.cwd(), args[3]);
+
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+  } catch (error) {
+    console.log(error);
+    process.exit();
+  }
+}
+
 const input = path.resolve(process.cwd(), args[0]);
 const output = path.resolve(process.cwd(), args[1]);
 
-require("./index")(input, output);
+require("./index")(input, output, config);

--- a/src/convert.js
+++ b/src/convert.js
@@ -1,4 +1,4 @@
-module.exports = function(input) {
+module.exports = function(input, config) {
   const fs = require("fs");
   const path = require("path");
   const Mustache = require("mustache");
@@ -13,5 +13,5 @@ module.exports = function(input) {
   const convert = input.endsWith(".adoc")
     ? require("./converter/adoc")
     : require("./converter/markdown");
-  return Mustache.render(template, convert(body));
+  return Mustache.render(template, convert(body, config));
 };

--- a/src/converter/adoc.js
+++ b/src/converter/adoc.js
@@ -1,6 +1,6 @@
 const { JSDOM } = require("jsdom");
 
-module.exports = function(body) {
+module.exports = function(body, config) {
   const asciidoctor = require("asciidoctor")();
   const content = asciidoctor.convert(body, {
     attributes: { showtitle: true }
@@ -22,6 +22,7 @@ module.exports = function(body) {
   }
 
   return (data = {
+    ...config,
     content: steps.join("\n"),
     title: dom.window.document.querySelector("h1").innerHTML
   });

--- a/src/converter/markdown.js
+++ b/src/converter/markdown.js
@@ -1,6 +1,6 @@
 const { JSDOM } = require("jsdom");
 
-module.exports = function(body) {
+module.exports = function (body, config) {
   const showdown = require("showdown"),
     converter = new showdown.Converter();
   const content = converter.makeHtml(body.toString());
@@ -31,7 +31,8 @@ module.exports = function(body) {
   }
 
   return {
+    ...config,
     content: steps.join("\n"),
-    title: dom.window.document.querySelector("h1").innerHTML
+    title: dom.window.document.querySelector("h1").innerHTML,
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-module.exports = function(input, target) {
+module.exports = function (input, target, config) {
   const fs = require("fs");
 
-  const html = require("./convert")(input);
+  const html = require("./convert")(input, config);
 
   const rimraf = require("rimraf");
 
@@ -17,7 +17,6 @@ module.exports = function(input, target) {
           return mkdir$(target);
         })
         .then(() => {
-          console.log("downloading template");
           return git$()
             .silent(true)
             .clone(
@@ -28,6 +27,6 @@ module.exports = function(input, target) {
 
   p.then(() => {
     return fs.writeFileSync(target + "/index.html", html);
-  }).catch(err => console.error(err));
+  }).catch((err) => console.error(err));
   return p;
 };

--- a/src/template.html
+++ b/src/template.html
@@ -9,8 +9,8 @@
     <meta name="theme-color" content="#4F7DC9" />
     <meta charset="UTF-8" />
     <title>{{ title }}</title>
-    <script src="/bower_components/webcomponentsjs/webcomponents-lite.js"></script>
-    <link rel="import" href="/elements/codelab.html" />
+    <script src="{{ &base }}bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+    <link rel="import" href="{{ &base }}elements/codelab.html" />
     <link
       rel="stylesheet"
       href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono"


### PR DESCRIPTION
- [x] Add documentation
- [x] Now we are able to use configuration for the lab generation 👍 

In a near futur we can also this file to pass some news configurations like
- codelab main color
- end link url 
- ....

## Configuration

### Values

| Name | Values | Description                                   |
| ---- | ------ | --------------------------------------------- |
| base | ""     | The base url of bower_components and elements |

### Examples

From shell
```shell
npx @dxdeveloperexperience/codelab-generator ./index.adoc ./target path/to/config.json

npx @dxdeveloperexperience/codelab-generator ./index.md ./target path/to/config.json
```

the config.json

```json
{
  "base": "baseurl/test/"
}
```

or

```js
const codelab = require("@dxdeveloperexperience/codelab-generator");

// ...
await codelab(labTmpFile, labsOutputDir, { base: "" });
```

Result, it will convert template
from:

```html
<script src="{{ &base }}bower_components/webcomponentsjs/webcomponents-lite.js"></script>
<link rel="import" href="{{ &base }}elements/codelab.html" />
```

to:

```html
<script src="baseurl/test/bower_components/webcomponentsjs/webcomponents-lite.js"></script>
<link rel="import" href="baseurl/test/elements/codelab.html" />
```