### PR TITLE
fix: config is 3 argument, but second in array position

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -12,7 +12,7 @@ if (args.length < 2) {
 }
 
 if (args.length === 3) {
-  const configPath = path.resolve(process.cwd(), args[3]);
+  const configPath = path.resolve(process.cwd(), args[2]);
 
   try {
     config = JSON.parse(fs.readFileSync(configPath, "utf8"));


### PR DESCRIPTION
This is making the config via cli work, otherwise it can't read the config